### PR TITLE
SongDTO 기반 노래 목록 조회

### DIFF
--- a/src/main/java/com/example/rhythme/controller/SongController.java
+++ b/src/main/java/com/example/rhythme/controller/SongController.java
@@ -1,0 +1,31 @@
+package com.example.rhythme.controller;
+
+import com.example.rhythme.dto.SongDTO;
+import com.example.rhythme.service.SongService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/songs")
+public class SongController {
+    private final SongService songService;
+
+    @Autowired
+    public SongController(SongService songService){
+        this.songService = songService;
+    }
+
+    @GetMapping("/all")
+    public ResponseEntity<List<SongDTO>> loadAllSongs() {
+        List<SongDTO> songs = songService.loadAllSongs();
+        if (songs.isEmpty()) {
+            return ResponseEntity.noContent().build();
+        }
+        return ResponseEntity.ok(songs);
+    }
+}

--- a/src/main/java/com/example/rhythme/dao/SongDAO.java
+++ b/src/main/java/com/example/rhythme/dao/SongDAO.java
@@ -1,0 +1,11 @@
+package com.example.rhythme.dao;
+
+import com.example.rhythme.dto.SongDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+import java.util.List;
+
+@Mapper
+public interface SongDAO {
+    List<SongDTO> findAllSongs();
+}

--- a/src/main/java/com/example/rhythme/dto/SongDTO.java
+++ b/src/main/java/com/example/rhythme/dto/SongDTO.java
@@ -1,0 +1,12 @@
+package com.example.rhythme.dto;
+
+import lombok.Data;
+
+@Data
+public class SongDTO {
+    private Integer song_id;
+    private String title;
+    private String artist;
+    private String imageUrl;                // 프론트 이미지 URL 필드명과 일치
+    private Integer progress;               // 학습 진행도에 사용
+}

--- a/src/main/java/com/example/rhythme/dto/UserDTO.java
+++ b/src/main/java/com/example/rhythme/dto/UserDTO.java
@@ -8,5 +8,4 @@ public class UserDTO {
     private int user_id;
     private String username;
     private String password;
-
 }

--- a/src/main/java/com/example/rhythme/service/SongService.java
+++ b/src/main/java/com/example/rhythme/service/SongService.java
@@ -1,0 +1,9 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dto.SongDTO;
+
+import java.util.List;
+
+public interface SongService {
+    List<SongDTO> loadAllSongs();
+}

--- a/src/main/java/com/example/rhythme/service/SongServiceImpl.java
+++ b/src/main/java/com/example/rhythme/service/SongServiceImpl.java
@@ -1,0 +1,24 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dao.SongDAO;
+import com.example.rhythme.dto.SongDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+public class SongServiceImpl implements SongService {
+    private final SongDAO songDAO;
+
+    @Autowired
+    public SongServiceImpl(SongDAO songDAO) {
+        this.songDAO = songDAO;
+    }
+
+    @Override
+    public List<SongDTO> loadAllSongs() {
+        return songDAO.findAllSongs();
+    }
+
+}

--- a/src/main/resources/mapper/mapper.xml
+++ b/src/main/resources/mapper/mapper.xml
@@ -11,4 +11,9 @@
         SELECT * FROM users WHERE username = #{username}
     </select>
 
+    <select id="findAllSongs" resultType="com.example.rhythme.dto.SongDTO">
+        SELECT song_id, title, artist, audio_file AS imageUrl, NULL AS progress
+        FROM songs
+    </select>
+
 </mapper>


### PR DESCRIPTION
- SongDTO를 기준으로 노래 정보를 전달하도록 구조 정의
- /songs/all 엔드포인트에서 전체 노래 목록 조회 가능
- Service, Mapper, DAO 등 계층 분리하여 구성
- 노래 목록이 비어 있을 경우 204 No Content 반환