### PR TITLE
가장 최근 학습한 노래 조회 API 구현

### DIFF
--- a/src/main/java/com/example/rhythme/config/SecurityConfig.java
+++ b/src/main/java/com/example/rhythme/config/SecurityConfig.java
@@ -33,6 +33,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
         configuration.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",
                 "http://localhost:3002"
         ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));

--- a/src/main/java/com/example/rhythme/controller/RecentSongController.java
+++ b/src/main/java/com/example/rhythme/controller/RecentSongController.java
@@ -1,0 +1,31 @@
+package com.example.rhythme.controller;
+
+import com.example.rhythme.dto.RecentSongDTO;
+import com.example.rhythme.service.RankingService;
+import com.example.rhythme.service.RecentSongService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "http://localhost:3000")
+
+@RestController
+@RequestMapping("/api/recent")
+public class RecentSongController {
+    private final RecentSongService recentSongService;
+
+    @Autowired
+    public RecentSongController(RecentSongService recentSongService){
+        this.recentSongService = recentSongService;
+    }
+
+    @GetMapping("/{userId}")
+    public ResponseEntity<RecentSongDTO> loadRecentSong(@PathVariable int userId){
+        RecentSongDTO recentSong = recentSongService.loadRecentSong(userId);
+        if (recentSong == null) {
+            return ResponseEntity.notFound().build();
+        }
+        return ResponseEntity.ok(recentSong);
+    }
+
+}

--- a/src/main/java/com/example/rhythme/dao/RecentSongDAO.java
+++ b/src/main/java/com/example/rhythme/dao/RecentSongDAO.java
@@ -1,0 +1,9 @@
+package com.example.rhythme.dao;
+
+import com.example.rhythme.dto.RecentSongDTO;
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface RecentSongDAO {
+    RecentSongDTO findMostRecentSongByUserId(int userId);
+}

--- a/src/main/java/com/example/rhythme/dto/RecentSongDTO.java
+++ b/src/main/java/com/example/rhythme/dto/RecentSongDTO.java
@@ -1,0 +1,15 @@
+package com.example.rhythme.dto;
+
+import lombok.Data;
+
+import java.sql.Timestamp;
+
+@Data
+public class RecentSongDTO {
+    private int userId;
+    private int songId;
+    private String title;
+    private String artist;
+    private String audioFile;
+    private Timestamp lastLearnedAt;
+}

--- a/src/main/java/com/example/rhythme/service/RecentSongService.java
+++ b/src/main/java/com/example/rhythme/service/RecentSongService.java
@@ -1,0 +1,7 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dto.RecentSongDTO;
+
+public interface RecentSongService {
+    RecentSongDTO loadRecentSong(int userId);
+}

--- a/src/main/java/com/example/rhythme/service/RecentSongServiceImpl.java
+++ b/src/main/java/com/example/rhythme/service/RecentSongServiceImpl.java
@@ -1,0 +1,22 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dao.RecentSongDAO;
+import com.example.rhythme.dto.RecentSongDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecentSongServiceImpl implements RecentSongService{
+
+    private final RecentSongDAO recentSongDAO;
+
+    @Autowired
+    public RecentSongServiceImpl(RecentSongDAO recentSongDAO) {
+        this.recentSongDAO = recentSongDAO;
+    }
+
+    @Override
+    public RecentSongDTO loadRecentSong(int userId) {
+        return recentSongDAO.findMostRecentSongByUserId(userId);
+    }
+}

--- a/src/main/resources/mapper/RecentSongmapper.xml
+++ b/src/main/resources/mapper/RecentSongmapper.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.rhythme.dao.RecentSongDAO">
+
+    <select id="findMostRecentSongByUserId" resultType="com.example.rhythme.dto.RecentSongDTO">
+        SELECT rl.user_id, s.song_id, s.title, s.artist, s.audio_file, rl.last_learned_at
+        FROM recent_song_learning rl
+        JOIN songs s ON rl.song_id = s.song_id
+        WHERE rl.user_id = #{userId}
+        ORDER BY rl.last_learned_at DESC
+        LIMIT 1
+    </select>
+
+</mapper>


### PR DESCRIPTION
- userId 기준으로 recent_song_learning에서 가장 최근 학습한 곡 1개 조회 기능 구현

- RecentSongDTO, DAO, Service, Controller 계층 완성

- MyBatis XML 매퍼에 사용자별 최근 학습 노래 조회 쿼리 추가

- /api/recent/{userId} GET API 엔드포인트 작성

- RecentSongController에서 ResponseEntity를 활용해 데이터 없을 시 404 처리 적용