### PR TITLE
노래 기반 테스트 문장 및 정답 단어 조회 API 구현

### DIFF
--- a/src/main/java/com/example/rhythme/controller/VocabQuizController.java
+++ b/src/main/java/com/example/rhythme/controller/VocabQuizController.java
@@ -1,0 +1,25 @@
+package com.example.rhythme.controller;
+
+import com.example.rhythme.dto.VocabQuizDTO;
+import com.example.rhythme.service.VocabQuizService;
+import com.example.rhythme.service.VocabQuizServiceImpl;
+import org.springframework.web.bind.annotation.*;
+
+@CrossOrigin(origins = "http://localhost:3000")
+
+@RestController
+@RequestMapping("/api/vocab-quiz")
+public class VocabQuizController {
+
+    private final VocabQuizService vocabQuizService;
+
+    public VocabQuizController(VocabQuizService vocabQuizService){
+        this.vocabQuizService = vocabQuizService;
+    }
+
+    @GetMapping("/{songId}")
+    public VocabQuizDTO findQuiz(@PathVariable int songId) {
+        return vocabQuizService.findQuizBySongId(songId);
+    }
+
+}

--- a/src/main/java/com/example/rhythme/dao/VocabQuizDAO.java
+++ b/src/main/java/com/example/rhythme/dao/VocabQuizDAO.java
@@ -1,0 +1,10 @@
+package com.example.rhythme.dao;
+
+import com.example.rhythme.dto.VocabQuizDTO;
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+@Mapper
+public interface VocabQuizDAO {
+    VocabQuizDTO findQuizBySongId(@Param("songId") int songId);
+}

--- a/src/main/java/com/example/rhythme/dto/VocabQuizDTO.java
+++ b/src/main/java/com/example/rhythme/dto/VocabQuizDTO.java
@@ -1,0 +1,9 @@
+package com.example.rhythme.dto;
+
+import lombok.Data;
+
+@Data
+public class VocabQuizDTO {
+    private String sentence;
+    private String correctWord;
+}

--- a/src/main/java/com/example/rhythme/service/VocabQuizService.java
+++ b/src/main/java/com/example/rhythme/service/VocabQuizService.java
@@ -1,0 +1,8 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dao.VocabQuizDAO;
+import com.example.rhythme.dto.VocabQuizDTO;
+
+public interface VocabQuizService {
+    VocabQuizDTO findQuizBySongId(int songId);
+}

--- a/src/main/java/com/example/rhythme/service/VocabQuizServiceImpl.java
+++ b/src/main/java/com/example/rhythme/service/VocabQuizServiceImpl.java
@@ -1,0 +1,23 @@
+package com.example.rhythme.service;
+
+import com.example.rhythme.dao.VocabQuizDAO;
+import com.example.rhythme.dto.VocabQuizDTO;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class VocabQuizServiceImpl implements VocabQuizService {
+
+    private final VocabQuizDAO vocabQuizDAO;
+
+    @Autowired
+    public VocabQuizServiceImpl(VocabQuizDAO vocabQuizDAO) {
+        this.vocabQuizDAO = vocabQuizDAO;
+    }
+
+    @Override
+    public VocabQuizDTO findQuizBySongId(int songId) {
+        return vocabQuizDAO.findQuizBySongId(songId);
+    }
+
+}

--- a/src/main/resources/mapper/VocabQuizmapper.xml
+++ b/src/main/resources/mapper/VocabQuizmapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.example.rhythme.dao.VocabQuizDAO">
+
+    <select id="findQuizBySongId" resultType="com.example.rhythme.dto.VocabQuizDTO">
+        SELECT sentence, correct_word
+        FROM song_quiz
+        WHERE song_id = #{songId}
+        LIMIT 1
+    </select>
+
+</mapper>


### PR DESCRIPTION
- GET /api/vocab-quiz/{songId} 엔드포인트 추가
- VocabQuizDAO, Service, Controller 계층에 기능 구현
- VocabQuizDTO에 sentence, correctWord 포함
- MyBatis를 통해 song_id 기반 퀴즈 데이터 조회